### PR TITLE
Use Deno.execPath

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ deployctl deploy --project=demo --import-map=import_map.json mod.ts
 
 See the [TypeScript definition](/index.d.ts) for `AdapterOptions`. You can specify the build output directory and provide additional esbuild options.
 
+The `usage` option is used to determine where the current directory is (this is needed for the static and prerendered files). The default is `usage: 'deno'` which uses the `import.meta.url` to get the current directory.
+If you want to compile the result with `deno compile` you should use `usage: 'deno-compile'` which uses `Deno.execPath()` to get the current directory.
+
 ## Node and NPM modules
 
 Import Node modules in server routes with the `node:` prefix:

--- a/files/mod.ts
+++ b/files/mod.ts
@@ -8,7 +8,7 @@ const initialized = server.init({env: Deno.env.toObject()});
 const prerendered: Set<string> = new Set(PRERENDERED);
 
 const appDir = 'APP_DIR';
-const baseDir = dirname(new URL(import.meta.url).pathname);
+const baseDir = dirname(Deno.execPath());
 const rootDir = join(baseDir, 'static');
 
 Deno.serve(

--- a/files/mod.ts
+++ b/files/mod.ts
@@ -8,7 +8,7 @@ const initialized = server.init({env: Deno.env.toObject()});
 const prerendered: Set<string> = new Set(PRERENDERED);
 
 const appDir = 'APP_DIR';
-const baseDir = dirname(Deno.execPath());
+const baseDir = dirname(CURRENT_DIRNAME);
 const rootDir = join(baseDir, 'static');
 
 Deno.serve(

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,9 +1,10 @@
-import {Adapter} from '@sveltejs/kit';
-import {BuildOptions} from 'esbuild';
+import { Adapter } from "@sveltejs/kit";
+import { BuildOptions } from "esbuild";
 
 interface AdapterOptions {
   out?: string;
   buildOptions?: BuildOptions;
+  usage?: "deno" | "deno-compile";
 }
 
 export default function plugin(options?: AdapterOptions): Adapter;

--- a/index.js
+++ b/index.js
@@ -1,9 +1,14 @@
-import {fileURLToPath} from 'node:url';
-import {build} from 'esbuild';
+import { fileURLToPath } from 'node:url';
+import { build } from 'esbuild';
+
+const usageOptions = {
+  deno: "deno",
+  compile: "deno-compile"
+}
 
 /** @type {import('.').default} */
 export default function (opts = {}) {
-  const {out = 'build', buildOptions = {}} = opts;
+  const { out = 'build', buildOptions = {}, usage = usageOptions.deno } = opts;
 
   return {
     name: 'deno-deploy-adapter',
@@ -31,7 +36,8 @@ export default function (opts = {}) {
         replace: {
           SERVER: './server.js',
           APP_DIR: builder.getAppPath(),
-          PRERENDERED: JSON.stringify(builder.prerendered.paths)
+          PRERENDERED: JSON.stringify(builder.prerendered.paths),
+          CURRENT_DIRNAME: usage === usageOptions.deno ? "new URL(import.meta.url).pathname" : "Deno.execPath()"
         }
       });
 


### PR DESCRIPTION
The current `new URL(import.meta.url).pathname` will not resolve to the current path if we use `deno compile`.