### PR TITLE
Windows filepath fix

### DIFF
--- a/files/mod.ts
+++ b/files/mod.ts
@@ -1,5 +1,5 @@
 import { serveDir, serveFile } from "file_server";
-import { dirname, extname, join } from "path";
+import { dirname, extname, join, fromFileUrl } from "path";
 
 import server from "SERVER";
 

--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ export default function (opts = {}) {
           APP_DIR: builder.getAppPath(),
           PRERENDERED: JSON.stringify(builder.prerendered.paths),
           CURRENT_DIRNAME: usage === usageOptions.deno
-            ? "new URL(import.meta.url).pathname"
+            ? "new URL(fromFileUrl(import.meta.url)).pathname"
             : "Deno.execPath()",
         },
       });

--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ export default function (opts = {}) {
           APP_DIR: builder.getAppPath(),
           PRERENDERED: JSON.stringify(builder.prerendered.paths),
           CURRENT_DIRNAME: usage === usageOptions.deno
-            ? "new URL(fromFileUrl(import.meta.url)).pathname"
+            ? "fromFileUrl(import.meta.url)"
             : "Deno.execPath()",
         },
       });


### PR DESCRIPTION
I was trying to run a SvelteKit + Deno project from a Windows computer and was running into some issues with the file server due to Windows not accepting file paths with a leading slash.

The problem, and a fix for it, was described in this issue: https://github.com/denoland/deno/issues/14605
I tried the fix on my Windows computer and it worked, so I applied the changes and opened this PR.